### PR TITLE
Fixed expansion not working

### DIFF
--- a/expansion/CompatWorldGuard/main/src/main/java/com/SirBlobman/expansion/worldguard/CompatWorldGuard.java
+++ b/expansion/CompatWorldGuard/main/src/main/java/com/SirBlobman/expansion/worldguard/CompatWorldGuard.java
@@ -46,7 +46,7 @@ public class CompatWorldGuard implements CLXExpansion, Listener {
     @Override
     public void load() {
         FOLDER = getDataFolder();
-        if(!PluginUtil.isEnabled("WorldGuard")) {
+        if(Util.PM.getPlugin("WorldGuard") == null) {
             print("WorldGuard is not installed, automatically disabling...");
             Expansions.unloadExpansion(this);
             return;


### PR DESCRIPTION
isEnabled() will always return false since the expansion is loaded before WorldGuard is enabled.