### PR TITLE
Avoid using BentoBox's SNAPSHOT builds

### DIFF
--- a/expansion/compatibility/SkyBlock/pom.xml
+++ b/expansion/compatibility/SkyBlock/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>world.bentobox</groupId>
             <artifactId>bentobox</artifactId>
-            <version>1.13.0-SNAPSHOT</version>
+            <version>1.12.0</version>
             <scope>provided</scope>
         </dependency>
         


### PR DESCRIPTION
Helps to avoid having CombatLogX builds ran every time BentoBox updates.