### PR TITLE
TownWars support

### DIFF
--- a/expansion/compatibility/Towny/src/main/java/com/SirBlobman/combatlogx/expansion/compatibility/towny/hook/HookTowny.java
+++ b/expansion/compatibility/Towny/src/main/java/com/SirBlobman/combatlogx/expansion/compatibility/towny/hook/HookTowny.java
@@ -45,7 +45,7 @@ public final class HookTowny {
         if(townyWorld == null || townyWorld.isForcePVP()) return false;
         
         Town town = getTown(location);
-        if (town == null || town.isPVP()) return false;
+        if (town == null || town.isPVP() || town.isAdminEnabledPVP()) return false;
         if (FlagWar.isUnderAttack(town)) return false;
 
         TownBlock townBlock = TownyAPI.getInstance().getTownBlock(location);


### PR DESCRIPTION
Check if the town has adminEnabledPvP.  This adds support for my https://github.com/MWHunter/TownWars plugin.