### PR TITLE
Could com.github.sirblobman.combatlogx.dummy:dummy-LegacyFactions:1.4.4 drop off redundant dependencies to loose weight?

### DIFF
--- a/dummy/LegacyFactions/pom.xml
+++ b/dummy/LegacyFactions/pom.xml
@@ -23,20 +23,34 @@
     </repositories>
 
     <dependencies>
-        <!-- JetBrains Annotations -->
-        <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <version>20.1.0</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Spigot API -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>${spigot.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.md-5</groupId>
+                    <artifactId>bungeecord-chat</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
@SirBlobman Hi, I am a user of project **_com.github.sirblobman.combatlogx.dummy:dummy-LegacyFactions:1.4.4_**. I found that its pom file introduced **_8_** dependencies. However, among them, **_6_** libraries (**_75%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_com.github.sirblobman.combatlogx.dummy:dummy-LegacyFactions:1.4.4_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
commons-lang:commons-lang:jar:2.6:provided
com.google.code.gson:gson:jar:2.8.0:provided
com.google.guava:guava:jar:21.0:provided
org.yaml:snakeyaml:jar:1.27:provided
net.md-5:bungeecord-chat:jar:1.16-R0.4:provided
org.jetbrains:annotations:jar:20.1.0:provided
</code></pre>