### PR TITLE
Fix errors for temporary players

### DIFF
--- a/expansion/force-field/src/main/java/combatlogx/expansion/force/field/listener/ForceFieldAdapter.java
+++ b/expansion/force-field/src/main/java/combatlogx/expansion/force/field/listener/ForceFieldAdapter.java
@@ -2,6 +2,7 @@ package combatlogx.expansion.force.field.listener;
 
 import java.util.UUID;
 
+import com.comphenix.protocol.injector.server.TemporaryPlayer;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -44,6 +45,8 @@ public class ForceFieldAdapter extends PacketAdapter {
         if(e.isCancelled()) return;
 
         Player player = e.getPlayer();
+        if(player instanceof TemporaryPlayer) return;
+
         ICombatManager combatManager = this.plugin.getCombatManager();
         if(!combatManager.isInCombat(player)) return;
 
@@ -76,6 +79,8 @@ public class ForceFieldAdapter extends PacketAdapter {
         if(e.isCancelled()) return;
 
         Player player = e.getPlayer();
+        if(player instanceof TemporaryPlayer) return;
+
         ICombatManager combatManager = this.plugin.getCombatManager();
         if(!combatManager.isInCombat(player)) return;
 


### PR DESCRIPTION
Temporary players do not have UUIDs. This should prevent an UnsupportedOperationException.