### PR TITLE
CheatPrevention: Fix not blocking physical interactions

### DIFF
--- a/expansion/cheat-prevention/expansion/src/main/java/combatlogx/expansion/cheat/prevention/listener/ListenerBlocks.java
+++ b/expansion/cheat-prevention/expansion/src/main/java/combatlogx/expansion/cheat/prevention/listener/ListenerBlocks.java
@@ -25,7 +25,7 @@ public final class ListenerBlocks extends CheatPreventionListener {
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onInteract(PlayerInteractEvent e) {
         Action action = e.getAction();
-        if(action != Action.RIGHT_CLICK_BLOCK && action != Action.LEFT_CLICK_BLOCK) {
+        if(action != Action.RIGHT_CLICK_BLOCK && action != Action.LEFT_CLICK_BLOCK && action != Action.PHYSICAL) {
             return;
         }
         


### PR DESCRIPTION
This fixes those interactions with blocks that are of the "PHYSICAL" type being ignored by the CheatPrevention expansion, e.g. triggering pressure plates.