### PR TITLE
Update Towny version required for Towny region expansion

### DIFF
--- a/expansion/compatibility/Towny/src/main/java/combatlogx/expansion/compatibility/region/towny/TownyExpansion.java
+++ b/expansion/compatibility/Towny/src/main/java/combatlogx/expansion/compatibility/region/towny/TownyExpansion.java
@@ -14,7 +14,7 @@ public final class TownyExpansion extends RegionExpansion {
     
     @Override
     public boolean checkDependencies() {
-        return checkDependency("Towny", true, "0.97");
+        return checkDependency("Towny", true, "0.98");
     }
     
     @Override


### PR DESCRIPTION
This PR bumps the Towny version required for the Towny expansion to 0.98.0.0 and above. Right now, the expansion fails to enable to any server using a 0.98 build with the message `"Dependency 'Towny' is not the correct version!"`.

* The expansion is being [built against](https://github.com/SirBlobman/CombatLogX/blob/main/expansion/compatibility/Towny/pom.xml#L34) the 0.98.1.10 dependency, not a 0.97 one.
* The last two stable releases of Towny have been of the 0.98 series and over [50.1%](https://bstats.org/plugin/bukkit/Towny/2244) of servers are using a 0.98 build. 
* Towny only began supporting 1.18 from 0.98.0.0 afterwards.
