### PR TITLE
Fix overriding wrong method

### DIFF
--- a/plugin/src/main/java/com/github/sirblobman/combatlogx/CombatPlugin.java
+++ b/plugin/src/main/java/com/github/sirblobman/combatlogx/CombatPlugin.java
@@ -188,7 +188,7 @@ public final class CombatPlugin extends ConfigurablePlugin implements ICombatLog
     }
 
     @Override
-    public CombatManager getCombatManager() {
+    public ICombatManager getCombatManager() {
         return this.combatManager;
     }
 


### PR DESCRIPTION
CombatPlugin was overriding wrong method. API has method returning only an interface. This mistake led to NoSuchMethodError.