### PR TITLE
Improvements to region knockback no-entry mode

### DIFF
--- a/api/src/main/java/com/github/sirblobman/combatlogx/api/expansion/region/RegionHandler.java
+++ b/api/src/main/java/com/github/sirblobman/combatlogx/api/expansion/region/RegionHandler.java
@@ -97,7 +97,9 @@ public abstract class RegionHandler {
             case CANCEL_EVENT:
                 e.setCancelled(true);
                 break;
+
             case KNOCKBACK_PLAYER:
+                e.setCancelled(true);
                 if (player.isInsideVehicle()) {
                     if (!player.leaveVehicle()) {
                         e.setCancelled(true);
@@ -172,8 +174,7 @@ public abstract class RegionHandler {
         double strength = getKnockbackStrength();
         Vector multiply = normal.multiply(strength);
 
-        Vector finite = makeFinite(multiply);
-        return finite.setY(0.0D);
+        return makeFinite(multiply);
     }
 
     private Vector makeFinite(Vector original) {


### PR DESCRIPTION
Fixes https://github.com/SirBlobman/CombatLogX/issues/472
This change ensures there is no possibly way for a player to enter the region when KNOCKBACK mode is set by cancelling the movement and then knocking back the player. 

Additionally, this change removes line 175-176 which was removing vertical trajectory of knockback. This was actually implemented here https://github.com/SirBlobman/CombatLogX/commit/14465d2387a02531a30d0cacfbfe789b1e814df5 to "fix players flying upwards" but causes players landing on the top of a region not bounce/knockback at all.