### PR TITLE
Lands

### DIFF
--- a/expansion/compatibility/Lands/build.gradle.kts
+++ b/expansion/compatibility/Lands/build.gradle.kts
@@ -4,5 +4,5 @@ repositories {
 
 dependencies {
     compileOnly(project(":expansion:newbie-helper"))
-    compileOnly("com.github.Angeschossen:LandsAPI:6.44.12")
+    compileOnly("com.github.Angeschossen:LandsAPI:6.44.13")
 }

--- a/expansion/compatibility/Lands/build.gradle.kts
+++ b/expansion/compatibility/Lands/build.gradle.kts
@@ -4,5 +4,5 @@ repositories {
 
 dependencies {
     compileOnly(project(":expansion:newbie-helper"))
-    compileOnly("com.github.Angeschossen:LandsAPI:6.42.0")
+    compileOnly("com.github.Angeschossen:LandsAPI:6.44.12")
 }

--- a/expansion/compatibility/Lands/src/main/java/combatlogx/expansion/compatibility/region/lands/RegionHandlerLands.java
+++ b/expansion/compatibility/Lands/src/main/java/combatlogx/expansion/compatibility/region/lands/RegionHandlerLands.java
@@ -48,6 +48,10 @@ public final class RegionHandlerLands extends RegionHandler<LandsExpansion> {
         }
 
         Entity enemy = tag.getCurrentEnemy();
+        if (enemy instanceof Player) { // if target is player, check for attack flag and wars. this makes sure that BOTH players are allowed to fight, not just the attacker, since attackers can only attack players that are allowed to fight back
+            return !area.canPvP(landsIntegration.getLandPlayer(player.getUniqueId(), enemy.getUniqueId(), false)); // if one of them can't fight, consider as safe zone, since it results in both of them not being able to fight in area
+        }
+
         TagType tagType = tag.getCurrentTagType();
         RoleFlag roleFlag = getRoleFlag(tagType, enemy);
         if (roleFlag == null) {

--- a/expansion/compatibility/Lands/src/main/java/combatlogx/expansion/compatibility/region/lands/RegionHandlerLands.java
+++ b/expansion/compatibility/Lands/src/main/java/combatlogx/expansion/compatibility/region/lands/RegionHandlerLands.java
@@ -49,7 +49,9 @@ public final class RegionHandlerLands extends RegionHandler<LandsExpansion> {
 
         Entity enemy = tag.getCurrentEnemy();
         if (enemy instanceof Player) { // if target is player, check for attack flag and wars. this makes sure that BOTH players are allowed to fight, not just the attacker, since attackers can only attack players that are allowed to fight back
-            return !area.canPvP(landsIntegration.getLandPlayer(player.getUniqueId(), enemy.getUniqueId(), false)); // if one of them can't fight, consider as safe zone, since it results in both of them not being able to fight in area
+            LandPlayer attacker = landsIntegration.getLandPlayer(player.getUniqueId()), target = landsIntegration.getLandPlayer(enemy.getUniqueId());
+            return !area.canPvP(attacker, target, false) // if one of them can't fight, consider as safe zone, since it results in both of them not being able to fight in area
+                    || area.canEnter(attacker, false) != area.canEnter(target, false); // if both of them can't enter: ignore, their entry will be denied by Lands anyway. Otherwise, make sure both of them can enter
         }
 
         TagType tagType = tag.getCurrentTagType();

--- a/expansion/compatibility/Lands/src/main/java/combatlogx/expansion/compatibility/region/lands/RegionHandlerLands.java
+++ b/expansion/compatibility/Lands/src/main/java/combatlogx/expansion/compatibility/region/lands/RegionHandlerLands.java
@@ -2,6 +2,7 @@ package combatlogx.expansion.compatibility.region.lands;
 
 import java.util.UUID;
 
+import me.angeschossen.lands.api.player.LandPlayer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 


### PR DESCRIPTION
# Observed Behavior
A landowner can enter the land, despite the tag enemy can't. 

# Expected Behavior
A landowner shouldn't be able to enter the land, if the tag enemy can't.

# Change
This PR fixes this behavior. It also adds support for Lands wars.