### PR TITLE
Fix async location lookup for Folia in ForceField expansion.

### DIFF
--- a/expansion/force-field/src/main/java/combatlogx/expansion/force/field/task/ForceFieldAdapter.java
+++ b/expansion/force-field/src/main/java/combatlogx/expansion/force/field/task/ForceFieldAdapter.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import com.github.sirblobman.api.folia.details.LocationTaskDetails;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -85,9 +86,14 @@ public final class ForceFieldAdapter extends PacketAdapter {
             return;
         }
 
-        if (isForceFieldBlock(task, player, location, tag)) {
-            sendForceField(task, player, location, packet);
-        }
+        getCombatLogX().getFoliaHelper().getScheduler().scheduleLocationTask(new LocationTaskDetails(plugin, location) {
+          @Override
+          public void run() {
+            if (isForceFieldBlock(task, player, location, tag)) {
+              sendForceField(task, player, location, packet);
+            }
+          }
+        });
     }
 
     @Override

--- a/expansion/force-field/src/main/java/combatlogx/expansion/force/field/task/ForceFieldTask.java
+++ b/expansion/force-field/src/main/java/combatlogx/expansion/force/field/task/ForceFieldTask.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.github.sirblobman.api.folia.details.LocationTaskDetails;
 import org.jetbrains.annotations.NotNull;
 
 import org.bukkit.Bukkit;
@@ -189,17 +190,22 @@ public final class ForceFieldTask extends ExpansionListener implements Runnable 
     }
 
     private void checkForceField(@NotNull Player player) {
-        if (hasBypass(player)) {
+      Location location = player.getLocation();
+      getCombatLogX().getFoliaHelper().getScheduler().scheduleLocationTask(new LocationTaskDetails(expansion.getPlugin().getPlugin(), location) {
+        @Override
+        public void run() {
+          if (hasBypass(player)) {
             removeForceField(player);
             return;
-        }
+          }
 
-        Location location = player.getLocation();
-        if (isSafe(player, location)) {
+          if (isSafe(player, location)) {
             return;
-        }
+          }
 
-        updateForceField(player);
+          updateForceField(player);
+        }
+      });
     }
 
     private boolean hasBypass(@NotNull Player player) {
@@ -385,7 +391,12 @@ public final class ForceFieldTask extends ExpansionListener implements Runnable 
         for (BlockLocation blockLocation : oldArea) {
             Location location = blockLocation.asLocation();
             if (location != null) {
-                resetBlock(player, location);
+              getCombatLogX().getFoliaHelper().getScheduler().scheduleLocationTask(new LocationTaskDetails(expansion.getPlugin().getPlugin(), location) {
+                @Override
+                public void run() {
+                  resetBlock(player, location);
+                }
+              });
             }
         }
     }


### PR DESCRIPTION
This PR should fix some issues that the ForceField expansion caused on Folia 1.20.4.

```
[15:53:58 WARN]: [CombatLogX] Async task for CombatLogX v11.4.0.1.1193 generated an exception
java.lang.NullPointerException: Cannot read field "captureTreeGeneration" because the return value of "net.minecraft.world.level.World.getCurrentWorldData()" is null
        at net.minecraft.world.level.Level.getBlockState(Level.java:1215) ~[?:?]
        at org.bukkit.craftbukkit.v1_20_R3.block.CraftBlock.getType(CraftBlock.java:238) ~[folia-1.20.4.jar:git-Folia-"25ee657"]
        at combatlogx.expansion.force.field.task.ForceFieldTask.canPlace(ForceFieldTask.java:178) ~[?:?]
```
```
[14:03:34 ERROR]: [CombatLogX] Unhandled exception occurred in onPacketReceiving(PacketEvent) for CombatLogX
java.lang.NullPointerException: Cannot read field "captureTreeGeneration" because the return value of "net.minecraft.world.level.World.getCurrentWorldData()" is null
        at net.minecraft.world.level.Level.getBlockState(Level.java:1215) ~[?:?]
        at org.bukkit.craftbukkit.v1_20_R3.block.CraftBlock.getType(CraftBlock.java:238) ~[folia-1.20.4.jar:git-Folia-"25ee657"]
        at combatlogx.expansion.force.field.task.ForceFieldTask.canPlace(ForceFieldTask.java:178) ~[?:?]
```