### PR TITLE
Add option to prevent new players from causing damage

### DIFF
--- a/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/configuration/NewbieHelperConfiguration.java
+++ b/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/configuration/NewbieHelperConfiguration.java
@@ -18,6 +18,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
     private int pvpToggleCooldown;
     private String permissionName;
     private boolean preventPvpToggleInDisabledWorlds;
+    private boolean newPlayerCauseDamage;
 
     private transient Permission permission;
 
@@ -30,12 +31,13 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         this.pvpToggleCooldown = 0;
         this.permissionName = null;
         this.preventPvpToggleInDisabledWorlds = true;
+        this.newPlayerCauseDamage = true;
 
         this.permission = null;
     }
 
     @Override
-    public void load(@NotNull ConfigurationSection config) {
+    public void load(@NotNull final ConfigurationSection config) {
         setNewPlayerProtection(config.getBoolean("new-player-protection", true));
         setRemoveProtectionOnAttack(config.getBoolean("remove-protection-on-attack", true));
         setProtectionTime(config.getLong("protection-time", 30_000L));
@@ -44,13 +46,14 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         setPvpToggleCooldown(config.getInt("pvp-toggle-cooldown", 0));
         setPermissionName(config.getString("pvp-toggle-cooldown-bypass-permission"));
         setPreventPvpToggleInDisabledWorlds(config.getBoolean("prevent-pvp-toggle-in-disabled-worlds", true));
+        setNewPlayerCauseDamage(config.getBoolean("new-player-cause-damage", true));
     }
 
     public boolean isNewPlayerProtection() {
         return this.newPlayerProtection;
     }
 
-    public void setNewPlayerProtection(boolean newPlayerProtection) {
+    public void setNewPlayerProtection(final boolean newPlayerProtection) {
         this.newPlayerProtection = newPlayerProtection;
     }
 
@@ -58,7 +61,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.removeProtectionOnAttack;
     }
 
-    public void setRemoveProtectionOnAttack(boolean removeProtectionOnAttack) {
+    public void setRemoveProtectionOnAttack(final boolean removeProtectionOnAttack) {
         this.removeProtectionOnAttack = removeProtectionOnAttack;
     }
 
@@ -66,7 +69,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.protectionTime;
     }
 
-    public void setProtectionTime(long protectionTime) {
+    public void setProtectionTime(final long protectionTime) {
         this.protectionTime = protectionTime;
     }
 
@@ -74,7 +77,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.mobProtection;
     }
 
-    public void setMobProtection(boolean mobProtection) {
+    public void setMobProtection(final boolean mobProtection) {
         this.mobProtection = mobProtection;
     }
 
@@ -82,7 +85,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.pvpToggleDefaultStatus;
     }
 
-    public void setPvpToggleDefaultStatus(boolean pvpToggleDefaultStatus) {
+    public void setPvpToggleDefaultStatus(final boolean pvpToggleDefaultStatus) {
         this.pvpToggleDefaultStatus = pvpToggleDefaultStatus;
     }
 
@@ -90,7 +93,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.pvpToggleCooldown;
     }
 
-    public void setPvpToggleCooldown(int pvpToggleCooldown) {
+    public void setPvpToggleCooldown(final int pvpToggleCooldown) {
         this.pvpToggleCooldown = pvpToggleCooldown;
     }
 
@@ -98,7 +101,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.permissionName;
     }
 
-    public void setPermissionName(@Nullable String permissionName) {
+    public void setPermissionName(@Nullable final String permissionName) {
         this.permissionName = permissionName;
     }
 
@@ -107,12 +110,12 @@ public final class NewbieHelperConfiguration implements IConfigurable {
             return this.permission;
         }
 
-        String permissionName = getPermissionName();
+        final String permissionName = getPermissionName();
         if (permissionName == null || permissionName.isEmpty()) {
             return null;
         }
 
-        String description = "CombatLogX Newbie Helper permission to bypass the cooldown for '/toggle-pvp'.";
+        final String description = "CombatLogX Newbie Helper permission to bypass the cooldown for '/toggle-pvp'.";
         this.permission = new Permission(permissionName, description, PermissionDefault.OP);
         return this.permission;
     }
@@ -121,7 +124,15 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.preventPvpToggleInDisabledWorlds;
     }
 
-    public void setPreventPvpToggleInDisabledWorlds(boolean preventPvpToggleInDisabledWorlds) {
+    public void setPreventPvpToggleInDisabledWorlds(final boolean preventPvpToggleInDisabledWorlds) {
         this.preventPvpToggleInDisabledWorlds = preventPvpToggleInDisabledWorlds;
+    }
+
+    public boolean isNewPlayerCauseDamage() {
+        return this.newPlayerCauseDamage;
+    }
+
+    private void setNewPlayerCauseDamage(final boolean newPlayerCauseDamage) {
+        this.newPlayerCauseDamage = newPlayerCauseDamage;
     }
 }

--- a/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/configuration/NewbieHelperConfiguration.java
+++ b/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/configuration/NewbieHelperConfiguration.java
@@ -132,7 +132,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.newPlayerCauseDamage;
     }
 
-    private void setNewPlayerCauseDamage(final boolean newPlayerCauseDamage) {
+    public void setNewPlayerCauseDamage(final boolean newPlayerCauseDamage) {
         this.newPlayerCauseDamage = newPlayerCauseDamage;
     }
 }

--- a/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/configuration/NewbieHelperConfiguration.java
+++ b/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/configuration/NewbieHelperConfiguration.java
@@ -9,7 +9,7 @@ import org.bukkit.permissions.PermissionDefault;
 
 import com.github.sirblobman.api.configuration.IConfigurable;
 
-public final class NewbieHelperConfiguration implements IConfigurable {
+public class NewbieHelperConfiguration implements IConfigurable {
     private boolean newPlayerProtection;
     private boolean removeProtectionOnAttack;
     private long protectionTime;
@@ -37,7 +37,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
     }
 
     @Override
-    public void load(@NotNull final ConfigurationSection config) {
+    public void load(@NotNull ConfigurationSection config) {
         setNewPlayerProtection(config.getBoolean("new-player-protection", true));
         setRemoveProtectionOnAttack(config.getBoolean("remove-protection-on-attack", true));
         setProtectionTime(config.getLong("protection-time", 30_000L));
@@ -53,7 +53,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.newPlayerProtection;
     }
 
-    public void setNewPlayerProtection(final boolean newPlayerProtection) {
+    public void setNewPlayerProtection(boolean newPlayerProtection) {
         this.newPlayerProtection = newPlayerProtection;
     }
 
@@ -61,7 +61,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.removeProtectionOnAttack;
     }
 
-    public void setRemoveProtectionOnAttack(final boolean removeProtectionOnAttack) {
+    public void setRemoveProtectionOnAttack(boolean removeProtectionOnAttack) {
         this.removeProtectionOnAttack = removeProtectionOnAttack;
     }
 
@@ -69,7 +69,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.protectionTime;
     }
 
-    public void setProtectionTime(final long protectionTime) {
+    public void setProtectionTime(long protectionTime) {
         this.protectionTime = protectionTime;
     }
 
@@ -77,7 +77,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.mobProtection;
     }
 
-    public void setMobProtection(final boolean mobProtection) {
+    public void setMobProtection(boolean mobProtection) {
         this.mobProtection = mobProtection;
     }
 
@@ -85,7 +85,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.pvpToggleDefaultStatus;
     }
 
-    public void setPvpToggleDefaultStatus(final boolean pvpToggleDefaultStatus) {
+    public void setPvpToggleDefaultStatus(boolean pvpToggleDefaultStatus) {
         this.pvpToggleDefaultStatus = pvpToggleDefaultStatus;
     }
 
@@ -93,7 +93,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.pvpToggleCooldown;
     }
 
-    public void setPvpToggleCooldown(final int pvpToggleCooldown) {
+    public void setPvpToggleCooldown(int pvpToggleCooldown) {
         this.pvpToggleCooldown = pvpToggleCooldown;
     }
 
@@ -101,7 +101,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.permissionName;
     }
 
-    public void setPermissionName(@Nullable final String permissionName) {
+    public void setPermissionName(@Nullable String permissionName) {
         this.permissionName = permissionName;
     }
 
@@ -110,12 +110,12 @@ public final class NewbieHelperConfiguration implements IConfigurable {
             return this.permission;
         }
 
-        final String permissionName = getPermissionName();
+        String permissionName = getPermissionName();
         if (permissionName == null || permissionName.isEmpty()) {
             return null;
         }
 
-        final String description = "CombatLogX Newbie Helper permission to bypass the cooldown for '/toggle-pvp'.";
+        String description = "CombatLogX Newbie Helper permission to bypass the cooldown for '/toggle-pvp'.";
         this.permission = new Permission(permissionName, description, PermissionDefault.OP);
         return this.permission;
     }
@@ -124,7 +124,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.preventPvpToggleInDisabledWorlds;
     }
 
-    public void setPreventPvpToggleInDisabledWorlds(final boolean preventPvpToggleInDisabledWorlds) {
+    public void setPreventPvpToggleInDisabledWorlds(boolean preventPvpToggleInDisabledWorlds) {
         this.preventPvpToggleInDisabledWorlds = preventPvpToggleInDisabledWorlds;
     }
 
@@ -132,7 +132,7 @@ public final class NewbieHelperConfiguration implements IConfigurable {
         return this.newPlayerCauseDamage;
     }
 
-    public void setNewPlayerCauseDamage(final boolean newPlayerCauseDamage) {
+    public void setNewPlayerCauseDamage(boolean newPlayerCauseDamage) {
         this.newPlayerCauseDamage = newPlayerCauseDamage;
     }
 }

--- a/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/configuration/NewbieHelperConfiguration.java
+++ b/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/configuration/NewbieHelperConfiguration.java
@@ -9,7 +9,7 @@ import org.bukkit.permissions.PermissionDefault;
 
 import com.github.sirblobman.api.configuration.IConfigurable;
 
-public class NewbieHelperConfiguration implements IConfigurable {
+public final class NewbieHelperConfiguration implements IConfigurable {
     private boolean newPlayerProtection;
     private boolean removeProtectionOnAttack;
     private long protectionTime;

--- a/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/listener/ListenerDamage.java
+++ b/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/listener/ListenerDamage.java
@@ -22,8 +22,8 @@ import combatlogx.expansion.newbie.helper.configuration.WorldsConfiguration;
 import combatlogx.expansion.newbie.helper.manager.PVPManager;
 import combatlogx.expansion.newbie.helper.manager.ProtectionManager;
 
-public class ListenerDamage extends ExpansionListener {
-    private NewbieHelperExpansion expansion;
+public final class ListenerDamage extends ExpansionListener {
+    private final NewbieHelperExpansion expansion;
 
     public ListenerDamage(@NotNull NewbieHelperExpansion expansion) {
         super(expansion);

--- a/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/listener/ListenerDamage.java
+++ b/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/listener/ListenerDamage.java
@@ -25,80 +25,76 @@ import combatlogx.expansion.newbie.helper.manager.ProtectionManager;
 public final class ListenerDamage extends ExpansionListener {
     private final NewbieHelperExpansion expansion;
 
-    public ListenerDamage(@NotNull NewbieHelperExpansion expansion) {
+    public ListenerDamage(@NotNull final NewbieHelperExpansion expansion) {
         super(expansion);
         this.expansion = expansion;
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onDamageByMob(EntityDamageByEntityEvent e) {
-        Entity damaged = e.getEntity();
-        if (!(damaged instanceof Player)) {
+    public void onDamageByMob(final EntityDamageByEntityEvent e) {
+        final Entity damaged = e.getEntity();
+        if (!(damaged instanceof final Player player)) {
             return;
         }
 
-        Player player = (Player) damaged;
         if (isWorldDisabled(player)) {
             return;
         }
 
-        Entity damager = getDamager(e);
+        final Entity damager = getDamager(e);
         if (damager instanceof Player) {
             return;
         }
 
-        ProtectionManager protectionManager = this.expansion.getProtectionManager();
+        final ProtectionManager protectionManager = this.expansion.getProtectionManager();
         if (protectionManager.isProtected(player) && isMobProtection()) {
             e.setCancelled(true);
         }
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onDamageMob(EntityDamageByEntityEvent e) {
-        Entity damaged = e.getEntity();
+    public void onDamageMob(final EntityDamageByEntityEvent e) {
+        final Entity damaged = e.getEntity();
         if (damaged instanceof Player) {
             return;
         }
 
-        Entity damager = getDamager(e);
-        if (!(damager instanceof Player)) {
+        final Entity damager = getDamager(e);
+        if (!(damager instanceof final Player player)) {
             return;
         }
 
-        Player player = (Player) damager;
         if (isWorldDisabled(player)) {
             return;
         }
 
-        ProtectionManager protectionManager = this.expansion.getProtectionManager();
+        final ProtectionManager protectionManager = this.expansion.getProtectionManager();
         if (protectionManager.isProtected(player) && isMobProtection()) {
             if (isRemoveProtectionOnAttack()) {
                 protectionManager.setProtected(player, false);
-                String messagePath = ("expansion.newbie-helper.protection-disabled.attacker");
-                LanguageManager languageManager = getLanguageManager();
+                final String messagePath = ("expansion.newbie-helper.protection-disabled.attacker");
+                final LanguageManager languageManager = getLanguageManager();
                 languageManager.sendMessageWithPrefix(player, messagePath);
             }
         }
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onDamageByPlayer(EntityDamageByEntityEvent e) {
-        Entity damaged = e.getEntity();
-        if (!(damaged instanceof Player)) {
+    public void onDamageByPlayer(final EntityDamageByEntityEvent e) {
+        final Entity damaged = e.getEntity();
+        if (!(damaged instanceof final Player attacked)) {
             return;
         }
 
-        Player attacked = (Player) damaged;
         if (isWorldDisabled(attacked)) {
             return;
         }
 
-        Entity damager = getDamager(e);
-        if (!(damager instanceof Player)) {
+        final Entity damager = getDamager(e);
+        if (!(damager instanceof final Player attacker)) {
             return;
         }
 
-        Player attacker = (Player) damager;
         if (isWorldDisabled(attacker)) {
             return;
         }
@@ -112,10 +108,10 @@ public final class ListenerDamage extends ExpansionListener {
             return;
         }
 
-        NewbieHelperExpansion expansion = getNewbieHelperExpansion();
-        ProtectionManager protectionManager = expansion.getProtectionManager();
-        PVPManager pvpManager = expansion.getPVPManager();
-        LanguageManager languageManager = getLanguageManager();
+        final NewbieHelperExpansion expansion = getNewbieHelperExpansion();
+        final ProtectionManager protectionManager = expansion.getProtectionManager();
+        final PVPManager pvpManager = expansion.getPVPManager();
+        final LanguageManager languageManager = getLanguageManager();
 
         if (pvpManager.isDisabled(attacked)) {
             e.setCancelled(true);
@@ -131,7 +127,7 @@ public final class ListenerDamage extends ExpansionListener {
 
         if (protectionManager.isProtected(attacked)) {
             e.setCancelled(true);
-            String messagePath = ("expansion.newbie-helper.no-pvp.protected");
+            final String messagePath = ("expansion.newbie-helper.no-pvp.protected");
             languageManager.sendMessageWithPrefix(attacker, messagePath);
             return;
         }
@@ -139,7 +135,13 @@ public final class ListenerDamage extends ExpansionListener {
         if (protectionManager.isProtected(attacker)) {
             if (isRemoveProtectionOnAttack()) {
                 protectionManager.setProtected(attacker, false);
-                String messagePath = ("expansion.newbie-helper.protection-disabled.attacker");
+                final String messagePath = ("expansion.newbie-helper.protection-disabled.attacker");
+                languageManager.sendMessageWithPrefix(attacker, messagePath);
+                return;
+            }
+            if (!isNewPlayerCauseDamage()) {
+                e.setCancelled(true);
+                final String messagePath = ("expansion.newbie-helper.no-pvp.cancel");
                 languageManager.sendMessageWithPrefix(attacker, messagePath);
             }
         }
@@ -150,53 +152,58 @@ public final class ListenerDamage extends ExpansionListener {
     }
 
     private @NotNull NewbieHelperConfiguration getConfiguration() {
-        NewbieHelperExpansion expansion = getNewbieHelperExpansion();
+        final NewbieHelperExpansion expansion = getNewbieHelperExpansion();
         return expansion.getConfiguration();
     }
 
     private @NotNull WorldsConfiguration getWorldsConfiguration() {
-        NewbieHelperExpansion expansion = getNewbieHelperExpansion();
+        final NewbieHelperExpansion expansion = getNewbieHelperExpansion();
         return expansion.getWorldsConfiguration();
     }
 
-    private boolean isForcePvpWorld(@NotNull Entity entity) {
-        World world = entity.getWorld();
+    private boolean isForcePvpWorld(@NotNull final Entity entity) {
+        final World world = entity.getWorld();
         return isForcePvpWorld(world);
     }
 
-    private boolean isForcePvpWorld(@NotNull World world) {
-        WorldsConfiguration configuration = getWorldsConfiguration();
+    private boolean isForcePvpWorld(@NotNull final World world) {
+        final WorldsConfiguration configuration = getWorldsConfiguration();
         return configuration.isForcePvp(world);
     }
 
-    private boolean isNoPvpWorld(@NotNull Entity entity) {
-        World world = entity.getWorld();
+    private boolean isNoPvpWorld(@NotNull final Entity entity) {
+        final World world = entity.getWorld();
         return isNoPvpWorld(world);
     }
 
-    private boolean isNoPvpWorld(@NotNull World world) {
-        WorldsConfiguration configuration = getWorldsConfiguration();
+    private boolean isNoPvpWorld(@NotNull final World world) {
+        final WorldsConfiguration configuration = getWorldsConfiguration();
         return configuration.isNoPvp(world);
     }
 
     private boolean isRemoveProtectionOnAttack() {
-        NewbieHelperConfiguration configuration = getConfiguration();
+        final NewbieHelperConfiguration configuration = getConfiguration();
         return configuration.isRemoveProtectionOnAttack();
     }
 
+    private boolean isNewPlayerCauseDamage() {
+        final NewbieHelperConfiguration configuration = getConfiguration();
+        return configuration.isNewPlayerCauseDamage();
+    }
+
     private boolean isMobProtection() {
-        NewbieHelperConfiguration configuration = getConfiguration();
+        final NewbieHelperConfiguration configuration = getConfiguration();
         return configuration.isMobProtection();
     }
 
-    private @NotNull Entity getDamager(@NotNull EntityDamageByEntityEvent e) {
-        Entity entity = e.getDamager();
+    private @NotNull Entity getDamager(@NotNull final EntityDamageByEntityEvent e) {
+        final Entity entity = e.getDamager();
         return getDamager(entity);
     }
 
     private @NotNull Entity getDamager(@NotNull Entity entity) {
-        ICombatLogX plugin = getCombatLogX();
-        MainConfiguration configuration = plugin.getConfiguration();
+        final ICombatLogX plugin = getCombatLogX();
+        final MainConfiguration configuration = plugin.getConfiguration();
 
         if (configuration.isLinkProjectiles()) {
             entity = EntityHelper.linkProjectile(plugin, entity);
@@ -211,10 +218,10 @@ public final class ListenerDamage extends ExpansionListener {
         }
 
         if (configuration.isLinkEndCrystals()) {
-            ICombatLogX combatLogX = getCombatLogX();
-            ICrystalManager crystalManager = combatLogX.getCrystalManager();
+            final ICombatLogX combatLogX = getCombatLogX();
+            final ICrystalManager crystalManager = combatLogX.getCrystalManager();
 
-            Player player = crystalManager.getPlacer(entity);
+            final Player player = crystalManager.getPlacer(entity);
             if (player != null) {
                 entity = player;
             }

--- a/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/listener/ListenerDamage.java
+++ b/expansion/newbie-helper/src/main/java/combatlogx/expansion/newbie/helper/listener/ListenerDamage.java
@@ -22,18 +22,18 @@ import combatlogx.expansion.newbie.helper.configuration.WorldsConfiguration;
 import combatlogx.expansion.newbie.helper.manager.PVPManager;
 import combatlogx.expansion.newbie.helper.manager.ProtectionManager;
 
-public final class ListenerDamage extends ExpansionListener {
-    private final NewbieHelperExpansion expansion;
+public class ListenerDamage extends ExpansionListener {
+    private NewbieHelperExpansion expansion;
 
-    public ListenerDamage(@NotNull final NewbieHelperExpansion expansion) {
+    public ListenerDamage(@NotNull NewbieHelperExpansion expansion) {
         super(expansion);
         this.expansion = expansion;
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onDamageByMob(final EntityDamageByEntityEvent e) {
-        final Entity damaged = e.getEntity();
-        if (!(damaged instanceof final Player player)) {
+    public void onDamageByMob(EntityDamageByEntityEvent e) {
+        Entity damaged = e.getEntity();
+        if (!(damaged instanceof Player player)) {
             return;
         }
 
@@ -41,26 +41,26 @@ public final class ListenerDamage extends ExpansionListener {
             return;
         }
 
-        final Entity damager = getDamager(e);
+        Entity damager = getDamager(e);
         if (damager instanceof Player) {
             return;
         }
 
-        final ProtectionManager protectionManager = this.expansion.getProtectionManager();
+        ProtectionManager protectionManager = this.expansion.getProtectionManager();
         if (protectionManager.isProtected(player) && isMobProtection()) {
             e.setCancelled(true);
         }
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onDamageMob(final EntityDamageByEntityEvent e) {
-        final Entity damaged = e.getEntity();
+    public void onDamageMob(EntityDamageByEntityEvent e) {
+        Entity damaged = e.getEntity();
         if (damaged instanceof Player) {
             return;
         }
 
-        final Entity damager = getDamager(e);
-        if (!(damager instanceof final Player player)) {
+        Entity damager = getDamager(e);
+        if (!(damager instanceof Player player)) {
             return;
         }
 
@@ -68,21 +68,21 @@ public final class ListenerDamage extends ExpansionListener {
             return;
         }
 
-        final ProtectionManager protectionManager = this.expansion.getProtectionManager();
+        ProtectionManager protectionManager = this.expansion.getProtectionManager();
         if (protectionManager.isProtected(player) && isMobProtection()) {
             if (isRemoveProtectionOnAttack()) {
                 protectionManager.setProtected(player, false);
-                final String messagePath = ("expansion.newbie-helper.protection-disabled.attacker");
-                final LanguageManager languageManager = getLanguageManager();
+                String messagePath = ("expansion.newbie-helper.protection-disabled.attacker");
+                LanguageManager languageManager = getLanguageManager();
                 languageManager.sendMessageWithPrefix(player, messagePath);
             }
         }
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
-    public void onDamageByPlayer(final EntityDamageByEntityEvent e) {
-        final Entity damaged = e.getEntity();
-        if (!(damaged instanceof final Player attacked)) {
+    public void onDamageByPlayer(EntityDamageByEntityEvent e) {
+        Entity damaged = e.getEntity();
+        if (!(damaged instanceof Player attacked)) {
             return;
         }
 
@@ -90,8 +90,8 @@ public final class ListenerDamage extends ExpansionListener {
             return;
         }
 
-        final Entity damager = getDamager(e);
-        if (!(damager instanceof final Player attacker)) {
+        Entity damager = getDamager(e);
+        if (!(damager instanceof Player attacker)) {
             return;
         }
 
@@ -108,10 +108,10 @@ public final class ListenerDamage extends ExpansionListener {
             return;
         }
 
-        final NewbieHelperExpansion expansion = getNewbieHelperExpansion();
-        final ProtectionManager protectionManager = expansion.getProtectionManager();
-        final PVPManager pvpManager = expansion.getPVPManager();
-        final LanguageManager languageManager = getLanguageManager();
+        NewbieHelperExpansion expansion = getNewbieHelperExpansion();
+        ProtectionManager protectionManager = expansion.getProtectionManager();
+        PVPManager pvpManager = expansion.getPVPManager();
+        LanguageManager languageManager = getLanguageManager();
 
         if (pvpManager.isDisabled(attacked)) {
             e.setCancelled(true);
@@ -127,7 +127,7 @@ public final class ListenerDamage extends ExpansionListener {
 
         if (protectionManager.isProtected(attacked)) {
             e.setCancelled(true);
-            final String messagePath = ("expansion.newbie-helper.no-pvp.protected");
+            String messagePath = ("expansion.newbie-helper.no-pvp.protected");
             languageManager.sendMessageWithPrefix(attacker, messagePath);
             return;
         }
@@ -135,13 +135,13 @@ public final class ListenerDamage extends ExpansionListener {
         if (protectionManager.isProtected(attacker)) {
             if (isRemoveProtectionOnAttack()) {
                 protectionManager.setProtected(attacker, false);
-                final String messagePath = ("expansion.newbie-helper.protection-disabled.attacker");
+                String messagePath = ("expansion.newbie-helper.protection-disabled.attacker");
                 languageManager.sendMessageWithPrefix(attacker, messagePath);
                 return;
             }
             if (!isNewPlayerCauseDamage()) {
                 e.setCancelled(true);
-                final String messagePath = ("expansion.newbie-helper.no-pvp.cancel");
+                String messagePath = ("expansion.newbie-helper.no-pvp.cancel");
                 languageManager.sendMessageWithPrefix(attacker, messagePath);
             }
         }
@@ -152,58 +152,58 @@ public final class ListenerDamage extends ExpansionListener {
     }
 
     private @NotNull NewbieHelperConfiguration getConfiguration() {
-        final NewbieHelperExpansion expansion = getNewbieHelperExpansion();
+        NewbieHelperExpansion expansion = getNewbieHelperExpansion();
         return expansion.getConfiguration();
     }
 
     private @NotNull WorldsConfiguration getWorldsConfiguration() {
-        final NewbieHelperExpansion expansion = getNewbieHelperExpansion();
+        NewbieHelperExpansion expansion = getNewbieHelperExpansion();
         return expansion.getWorldsConfiguration();
     }
 
-    private boolean isForcePvpWorld(@NotNull final Entity entity) {
-        final World world = entity.getWorld();
+    private boolean isForcePvpWorld(@NotNull Entity entity) {
+        World world = entity.getWorld();
         return isForcePvpWorld(world);
     }
 
-    private boolean isForcePvpWorld(@NotNull final World world) {
-        final WorldsConfiguration configuration = getWorldsConfiguration();
+    private boolean isForcePvpWorld(@NotNull World world) {
+        WorldsConfiguration configuration = getWorldsConfiguration();
         return configuration.isForcePvp(world);
     }
 
-    private boolean isNoPvpWorld(@NotNull final Entity entity) {
-        final World world = entity.getWorld();
+    private boolean isNoPvpWorld(@NotNull Entity entity) {
+        World world = entity.getWorld();
         return isNoPvpWorld(world);
     }
 
-    private boolean isNoPvpWorld(@NotNull final World world) {
-        final WorldsConfiguration configuration = getWorldsConfiguration();
+    private boolean isNoPvpWorld(@NotNull World world) {
+        WorldsConfiguration configuration = getWorldsConfiguration();
         return configuration.isNoPvp(world);
     }
 
     private boolean isRemoveProtectionOnAttack() {
-        final NewbieHelperConfiguration configuration = getConfiguration();
+        NewbieHelperConfiguration configuration = getConfiguration();
         return configuration.isRemoveProtectionOnAttack();
     }
 
     private boolean isNewPlayerCauseDamage() {
-        final NewbieHelperConfiguration configuration = getConfiguration();
+        NewbieHelperConfiguration configuration = getConfiguration();
         return configuration.isNewPlayerCauseDamage();
     }
 
     private boolean isMobProtection() {
-        final NewbieHelperConfiguration configuration = getConfiguration();
+        NewbieHelperConfiguration configuration = getConfiguration();
         return configuration.isMobProtection();
     }
 
-    private @NotNull Entity getDamager(@NotNull final EntityDamageByEntityEvent e) {
-        final Entity entity = e.getDamager();
+    private @NotNull Entity getDamager(@NotNull EntityDamageByEntityEvent e) {
+        Entity entity = e.getDamager();
         return getDamager(entity);
     }
 
     private @NotNull Entity getDamager(@NotNull Entity entity) {
-        final ICombatLogX plugin = getCombatLogX();
-        final MainConfiguration configuration = plugin.getConfiguration();
+        ICombatLogX plugin = getCombatLogX();
+        MainConfiguration configuration = plugin.getConfiguration();
 
         if (configuration.isLinkProjectiles()) {
             entity = EntityHelper.linkProjectile(plugin, entity);
@@ -218,10 +218,10 @@ public final class ListenerDamage extends ExpansionListener {
         }
 
         if (configuration.isLinkEndCrystals()) {
-            final ICombatLogX combatLogX = getCombatLogX();
-            final ICrystalManager crystalManager = combatLogX.getCrystalManager();
+            ICombatLogX combatLogX = getCombatLogX();
+            ICrystalManager crystalManager = combatLogX.getCrystalManager();
 
-            final Player player = crystalManager.getPlacer(entity);
+            Player player = crystalManager.getPlacer(entity);
             if (player != null) {
                 entity = player;
             }

--- a/expansion/newbie-helper/src/main/resources/config.yml
+++ b/expansion/newbie-helper/src/main/resources/config.yml
@@ -2,6 +2,10 @@
 # Default: true
 new-player-protection: true
 
+# Should new players cause damage to other players?
+# Default: true
+new-player-cause-damage: true
+
 # Should new player protection be removed from a player if they attack someone?
 # Default: true
 remove-protection-on-attack: true

--- a/expansion/newbie-helper/src/main/resources/expansion.yml
+++ b/expansion/newbie-helper/src/main/resources/expansion.yml
@@ -3,5 +3,5 @@ prefix: "${expansionPrefix}"
 description: "${expansionDescription}"
 
 main: "combatlogx.expansion.newbie.helper.NewbieHelperExpansion"
-version: "17.3"
+version: "17.4"
 author: "SirBlobman"

--- a/plugin/src/main/resources/language/en_us.lang.yml
+++ b/plugin/src/main/resources/language/en_us.lang.yml
@@ -390,6 +390,7 @@ expansion:
       self: "<red>You are not allowed to hit that player while your PvP is disabled.</red>"
       other: "<red>That player has PvP disabled.</red>"
       protected: "<red>That player is protected, you are not allowed to attack them yet!</red>"
+      cancel: "<red>You are protected, you are not allowed to attack other players yet!</red>"
 
     protection-disabled:
       # Shown when newbie protection is disabled due to the player attacking another player.


### PR DESCRIPTION
Introduces the 'new-player-cause-damage' configuration option to control whether new players with protection can damage others. Updates event listeners to respect this setting and adds a new language message for when protected players are prevented from attacking. Bumps expansion version to 17.4.