### PR TITLE
Add Citizens 2.0.42 compatibility

### DIFF
--- a/expansion/compatibility/Citizens/build.gradle.kts
+++ b/expansion/compatibility/Citizens/build.gradle.kts
@@ -3,6 +3,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly("net.citizensnpcs:citizensapi:2.0.40-SNAPSHOT")
+    compileOnly("net.citizensnpcs:citizensapi:2.0.42-SNAPSHOT")
     compileOnly("org.mcmonkey:sentinel:2.9.0-SNAPSHOT")
 }

--- a/expansion/compatibility/Citizens/src/main/java/combatlogx/expansion/compatibility/citizens/CitizensExpansion.java
+++ b/expansion/compatibility/Citizens/src/main/java/combatlogx/expansion/compatibility/citizens/CitizensExpansion.java
@@ -32,7 +32,7 @@ public final class CitizensExpansion extends Expansion {
     private static final List<String> SUPPORTED_VERSION_LIST;
 
     static {
-        SUPPORTED_VERSION_LIST = Arrays.asList("2.0.35", "2.0.36", "2.0.37", "2.0.38", "2.0.39", "2.0.40");
+        SUPPORTED_VERSION_LIST = Arrays.asList("2.0.35", "2.0.36", "2.0.37", "2.0.38", "2.0.39", "2.0.40", "2.0.41", "2.0.42");
     }
 
     private final Configuration configuration;

--- a/expansion/compatibility/Citizens/src/main/resources/expansion.yml
+++ b/expansion/compatibility/Citizens/src/main/resources/expansion.yml
@@ -3,7 +3,7 @@ prefix: "${expansionPrefix}"
 description: "${expansionDescription}"
 
 main: "combatlogx.expansion.compatibility.citizens.CitizensExpansion"
-version: "17.18"
+version: "17.19"
 author: "SirBlobman"
 
 plugin-depend:


### PR DESCRIPTION
# Changes

- Update Citizens compatibility expansion to support Citizens 2.0.42

# Testing

I compiled and tested it on my server:
* Java 25
* Paper 1.21.11
* CombatLogX 11.7.0.0.1333
* Citizens 2.0.42-b4198

Loaded up successfully:

<img width="831" height="57" alt="Screenshot 2026-06-12 at 8 43 15 PM" src="https://github.com/user-attachments/assets/7c4a9845-aa6e-4a91-b05a-e7de2e7421a6" />

Was able to kill the combat-logged Citizen:

<img width="838" height="134" alt="Screenshot 2026-06-12 at 8 46 36 PM" src="https://github.com/user-attachments/assets/b620d3af-4bd3-4875-b5c8-12ca9d69286c" />
